### PR TITLE
Update notepad--.json with new extract_dir

### DIFF
--- a/bucket/notepad--.json
+++ b/bucket/notepad--.json
@@ -7,10 +7,10 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/cxasm/notepad--/releases/download/notepad-v3.6.3/Notepad--v3.6.3-win10-portable.zip",
-            "hash": "e64f613ac194720025bbee399247014cc9206240e4b65a4877279813d3f093a6"
+            "hash": "e64f613ac194720025bbee399247014cc9206240e4b65a4877279813d3f093a6",
+            "extract_dir": "Notepad--v3.6.3-win10-portable",
         }
     },
-    "extract_dir": "Notepad--v2.20.1-win10-portable",
     "shortcuts": [
         [
             "Notepad--.exe",


### PR DESCRIPTION
Added extract_dir for 64bit architecture and updated notes.

修复 `notepad--` 自动更新安装时无法解压错误版本路径的问题。

re: https://github.com/lzwme/scoop-proxy-cn/pull/102